### PR TITLE
Remove a:visited styles

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -101,10 +101,6 @@ a {
     color: $brand-color;
     text-decoration: none;
 
-    &:visited {
-        color: darken($brand-color, 15%);
-    }
-
     &:hover {
         color: $text-color;
         text-decoration: underline;


### PR DESCRIPTION
Visited links used to be drawn in a really dark red. There's no really good
reason why we need to make these darker, but it's much more readable if they
aren't.
